### PR TITLE
crawler_cei: Remove posfixo Fracionado(F) do ticker no df

### DIFF
--- a/src/crawler_cei.py
+++ b/src/crawler_cei.py
@@ -112,8 +112,12 @@ class CrawlerCei():
             else:
                 return 'Compra'
 
+        def remove_fracionado_ticker(ticker):
+            return ticker[:-1] if ticker.endswith('F') else ticker
+
         df['data'] = pd.to_datetime(df['data'], dayfirst=True)
         df['data'] = df['data'].dt.date
+        df['ticker'] = df.apply(lambda row: remove_fracionado_ticker(row.ticker), axis=1)
         df['operacao'] = df.apply(lambda row: formata_compra_venda(row.operacao), axis=1)
         df['qtd_ajustada'] = df.apply(lambda row: calculate_add(row), axis=1)
 


### PR DESCRIPTION
No meu CEI tinha alguns ativos com o posfixo de fracionado que estavam quebrando o script:
  File "C:\repos\ir\src\stuff.py", line 98, in calcula_custodia
    raise Exception('Erro ao calcular custodia do ticker {}'.format(ticker), ex)
Exception: ('Erro ao calcular custodia do ticker WEGE3F', AttributeError("'NoneType' object has no attribute 'name'"))

modifiquei no crawler_cei para remover o posfixo do dataframe a função __converte_dataframe_para_formato_padrao().